### PR TITLE
Sprint 8

### DIFF
--- a/cohorts/models.py
+++ b/cohorts/models.py
@@ -119,7 +119,7 @@ class Cohort(models.Model):
     def get_data_sources(self, source_type=None):
         result = {}
 
-        cohort_filters = Filters.objects.filter(resulting_cohort=self)
+        cohort_filters = Filters.objects.select_related('attribute').filter(resulting_cohort=self)
         attributes = Attribute.objects.filter(id__in=cohort_filters.values_list('attribute', flat=True))
 
         data_versions = self.get_data_versions()
@@ -139,7 +139,7 @@ class Cohort(models.Model):
     # Returns the set of filters defining this cohort as a dict organized by data source
     def get_filters_by_data_source(self, source_type=None):
 
-        cohort_filters = Filters.objects.filter(resulting_cohort=self)
+        cohort_filters = Filters.objects.select_related('attribute').filter(resulting_cohort=self)
         result = self.get_data_sources(source_type)
 
         for source in DataSource.SOURCE_TYPES:

--- a/idc_collections/models.py
+++ b/idc_collections/models.py
@@ -194,11 +194,26 @@ class Attribute(models.Model):
             self.name, self.display_name, self.data_type)
 
 
+class Attribute_Display_ValuesQuerySet(models.QuerySet):
+    def to_dict(self):
+        dvals = {}
+        for dv in self.all().select_related('attribute'):
+            if dv.attribute.id not in dvals:
+                dvals[dv.attribute.id] = {}
+            dvals[dv.attribute.id][dv.raw_value] = dv.display_value
+
+        return dvals
+
+class Attribute_Display_ValuesManager(models.Manager):
+    def get_queryset(self):
+        return Attribute_Display_ValuesQuerySet(self.model, using=self._db)
+
 class Attribute_Display_Values(models.Model):
     id = models.AutoField(primary_key=True, null=False, blank=False)
     attribute = models.ForeignKey(Attribute, null=False, blank=False, on_delete=models.CASCADE)
     raw_value = models.CharField(max_length=256, null=False, blank=False)
     display_value = models.CharField(max_length=256, null=False, blank=False)
+    objects = Attribute_Display_ValuesManager()
 
     class Meta(object):
         unique_together = (("raw_value", "attribute"),)


### PR DESCRIPTION
- Use select_related to prevent multiple database hits on one-to-many relationships