### PR TITLE
Sprint 9

### DIFF
--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -197,8 +197,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                     where_clause="{}".format("WHERE {}".format(" AND ".join(query_filters)) if len(query_filters) else ""),
                     join_clause=""" """.join(joins),
                 )
-                if facet == 'Modality':
-                    print(count_query)
                 # Toggle 'don't filter'
                 if filtering_this_facet:
                     for param in filter_clauses[facet_table]['attr_params'][facet]:
@@ -210,7 +208,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                     for param in filter_clauses[facet_table]['attr_params'][facet]:
                         filter_clauses[facet_table]['count_params'][param]['parameterValue']['value'] = 'filtering'
 
-        start = time.time()
         not_done = True
         still_checking = True
         num_retries = 0
@@ -229,8 +226,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
         if not_done:
             logger.error("[ERROR] Timed out while trying to count case/sample totals in BQ")
         else:
-            stop = time.time()
-            logger.debug("[BENCHMARKING] Time to finish BQ counts: {}s".format(str(((stop-start)/1000))))
             for facet in count_jobs:
                 bq_results = BigQuerySupport.get_job_results(count_jobs[facet]['job']['jobReference'])
                 for row in bq_results:

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -112,8 +112,8 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
     param_sfx = 0
 
     results = {'facets': {
-        'cross_collex': {},
-        'clinical': {}
+        'origin_set': {},
+        'related_set': {}
     }}
 
     facet_map = {}
@@ -171,7 +171,7 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
         for facet_table in facet_attr_by_bq['sources']:
             for attr_facet in facet_attr_by_bq['sources'][facet_table]['attrs']:
                 facet = attr_facet.name
-                source_set = 'cross_collex' if table_info[facet_table]['type'] == DataVersion.IMAGE_DATA else 'clinical'
+                source_set = 'origin_set' if table_info[facet_table]['type'] == DataVersion.IMAGE_DATA else 'related_set'
                 if source_set not in results['facets']:
                     results['facets'][source_set] = { facet_table: {'facets': {}}}
                 if facet_table not in results['facets'][source_set]:

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -27,10 +27,40 @@ BQ_ATTEMPT_MAX = 10
 
 logger = logging.getLogger('main_logger')
 
+# If ancillary data is involved, only a SINGLE program (case superset) can be examined. This is because programs
+# often do not share data models, so filters for one program may not fit filters for another, resulting in
+# no records found should a given filter set be applied to multiple programs.
+#
+# If no ancillary data is requested, any number of image tables can be examined.
 
-def get_bq_facet_counts(filters, facets, data_versions):
+
+def _build_attr_by_source(attrs, data_versions, source_type):
+    attr_by_src = {}
+    attr_objs = Attribute.objects.filter(active=True, name__in=attrs)
+
+    for attr in attr_objs:
+        sources = attr.data_sources.all().select_related('version').filter(version__in=data_versions, source_type=source_type).distinct()
+        for source in sources:
+            if source.name not in attr_by_src:
+                attr_by_src[source.name] = {
+                    'shared_id_col': source.shared_id_col,
+                    'alias': source.name.split(".")[-1].lower().replace("-", "_"),
+                    'list': [attr.name],
+                    'attrs': [attr],
+                    'data_type': source.version.data_type
+                }
+            else:
+                attr_by_src[source.name]['list'].append(attr.name)
+                attr_by_src[source.name]['attrs'].append(attr)
+
+    return attr_by_src
+
+def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
     filter_attr_by_bq = {}
     facet_attr_by_bq = {}
+
+    counted_total = False
+    total = 0
 
     query_base = """
         #standardSQL
@@ -40,7 +70,7 @@ def get_bq_facet_counts(filters, facets, data_versions):
             FROM {table_clause} 
             {join_clause}
             {where_clause}
-            GROUP BY {count_clause}
+            GROUP BY {group_by_clause}
         )
         GROUP BY {facet}
     """
@@ -50,44 +80,30 @@ def get_bq_facet_counts(filters, facets, data_versions):
         ON {join_to_alias}.{join_to_id} = {join_from_alias}.{join_from_id}
     """
 
-    filter_attrs = Attribute.objects.filter(active=True, name__in=list(filters.keys()))
-    facet_attrs = Attribute.objects.filter(active=True, name__in=facets)
-
-    table_info = {}
-
     image_tables = {}
 
-    for attr in filter_attrs:
-        bqtables = attr.data_sources.all().filter(version__in=data_versions, source_type=DataSource.BIGQUERY).distinct()
-        for bqtable in bqtables:
-            if bqtable.version.data_type == DataVersion.IMAGE_DATA:
-                image_tables[bqtable.name] = bqtable
-            if bqtable.name not in filter_attr_by_bq:
-                filter_attr_by_bq[bqtable.name] = {}
-                table_info[bqtable.name] = {
-                    'id_col': bqtable.shared_id_col
-                }
-                alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
-                table_info[bqtable.name]['alias'] = alias
-                filter_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
-            else:
-                filter_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+    if not sources_and_attrs:
+        if not data_versions or not facets:
+            raise Exception("Can't determine facet attributes without facets and versions.")
+        filter_attr_by_bq = _build_attr_by_source(list(filters.keys()), data_versions, DataSource.BIGQUERY)
+        facet_attr_by_bq = _build_attr_by_source(facets, data_versions, DataSource.BIGQUERY)
+    else:
+        filter_attr_by_bq = sources_and_attrs['filters']
+        facet_attr_by_bq = sources_and_attrs['facets']
 
-    for attr in facet_attrs:
-        bqtables = attr.data_sources.all().filter(version__active=True, source_type=DataSource.BIGQUERY).distinct()
-        for bqtable in bqtables:
-            if bqtable.version.data_type == DataVersion.IMAGE_DATA:
-                image_tables[bqtable.name] = bqtable
-            if bqtable.name not in facet_attr_by_bq:
-                facet_attr_by_bq[bqtable.name] = {}
-                facet_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
-                table_info[bqtable.name] = {
-                    'id_col': bqtable.shared_id_col
-                }
-                alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
-                table_info[bqtable.name]['alias'] = alias
-            else:
-                facet_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+    for attr_set in [filter_attr_by_bq, facet_attr_by_bq]:
+        for source in attr_set['sources']:
+            if attr_set['sources'][source]['data_type'] == DataVersion.IMAGE_DATA:
+                image_tables[source] = 1
+
+    table_info = {
+        x: {
+            'name': y['sources'][x]['name'],
+            'alias': y['sources'][x]['name'].split(".")[-1].lower().replace("-", "_"),
+            'shared_id_col': y['sources'][x]['shared_id_col'],
+            'type': y['sources'][x]['data_type']
+        } for y in [facet_attr_by_bq, filter_attr_by_bq] for x in y['sources']
+    }
 
     filter_clauses = {}
 
@@ -95,64 +111,94 @@ def get_bq_facet_counts(filters, facets, data_versions):
     params = []
     param_sfx = 0
 
+    results = {'facets': {
+        'cross_collex': {},
+        'clinical': {}
+    }}
+
+    facet_map = {}
+
     # We join image tables to corresponding ancillary tables, and union between image tables
     for image_table in image_tables:
         tables_in_query = []
         joins = []
         query_filters = []
-        if image_table in filter_attr_by_bq:
-            filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[image_table]['attrs']}
-            filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
-                filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
-                case_insens=True, with_count_toggle=True
-            )
-            param_sfx += 1
-            query_filters.append(filter_clauses[image_table]['filter_string'])
-            params.append(filter_clauses[image_table]['parameters'])
-        tables_in_query.append(image_table)
-        for filter_bqtable in filter_attr_by_bq:
-            if filter_bqtable != image_table and filter_bqtable not in tables_in_query:
-                filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[filter_bqtable]['attrs']}
-                filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
-                    filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
+        if image_table in filter_attr_by_bq['sources']:
+            filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq['sources'][image_table]['list']}
+            if len(filter_set):
+                filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
+                    filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
                     case_insens=True, with_count_toggle=True
                 )
                 param_sfx += 1
+                query_filters.append(filter_clauses[image_table]['filter_string'])
+                params.append(filter_clauses[image_table]['parameters'])
+        tables_in_query.append(image_table)
+        for filter_bqtable in filter_attr_by_bq['sources']:
+            if filter_bqtable not in image_tables and filter_bqtable not in tables_in_query:
+                filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq['sources'][filter_bqtable]['list']}
+                if len(filter_set):
+                    filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
+                        filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
+                        case_insens=True, with_count_toggle=True
+                    )
+                    param_sfx += 1
 
-                joins.append(join_clause_base.format(
-                    join_to_table=filter_bqtable,
-                    join_to_alias=table_info[filter_bqtable]['alias'],
-                    join_to_id=table_info[filter_bqtable]['id_col'],
-                    join_from_alias=table_info[image_table]['alias'],
-                    join_from_id=table_info[image_table]['id_col']
-                ))
-                params.append(filter_clauses[filter_bqtable]['parameters'])
-                query_filters.append(filter_clauses[filter_bqtable]['filter_string'])
-                tables_in_query.append(filter_bqtable)
+                    joins.append(join_clause_base.format(
+                        join_to_table=table_info[filter_bqtable]['name'],
+                        join_to_alias=table_info[filter_bqtable]['alias'],
+                        join_to_id=table_info[filter_bqtable]['shared_id_col'],
+                        join_from_alias=table_info[image_table]['alias'],
+                        join_from_id=table_info[image_table]['shared_id_col']
+                    ))
+                    params.append(filter_clauses[filter_bqtable]['parameters'])
+                    query_filters.append(filter_clauses[filter_bqtable]['filter_string'])
+                    tables_in_query.append(filter_bqtable)
 
         # Any remaining facets not pulled are for tables not being filtered and which aren't the image table,
         # so we add them last
-        for facet_bqtable in facet_attr_by_bq:
-            if facet_bqtable not in tables_in_query:
+        for facet_bqtable in facet_attr_by_bq['sources']:
+            if facet_bqtable not in image_tables and facet_bqtable not in tables_in_query:
                 joins.append(join_clause_base.format(
                     join_from_alias=table_info[image_table]['alias'],
-                    join_from_id=table_info[image_table]['id_col'],
+                    join_from_id=table_info[image_table]['shared_id_col'],
                     join_to_alias=table_info[facet_bqtable]['alias'],
-                    join_to_table=facet_bqtable,
-                    join_to_id=table_info[facet_bqtable]['id_col']
+                    join_to_table=table_info[facet_bqtable]['name'],
+                    join_to_id=table_info[facet_bqtable]['shared_id_col']
                 ))
 
-        for facet_table in facet_attr_by_bq:
-            for facet in facet_attr_by_bq[facet_table]['attrs']:
+        # Submit jobs, toggling the 'don't filter' var for each facet
+        for facet_table in facet_attr_by_bq['sources']:
+            for attr_facet in facet_attr_by_bq['sources'][facet_table]['attrs']:
+                facet = attr_facet.name
+                source_set = 'cross_collex' if table_info[facet_table]['type'] == DataVersion.IMAGE_DATA else 'clinical'
+                if source_set not in results['facets']:
+                    results['facets'][source_set] = { facet_table: {'facets': {}}}
+                if facet_table not in results['facets'][source_set]:
+                    results['facets'][source_set][facet_table] = {'facets': {}}
+                results['facets'][source_set][facet_table]['facets'][facet] = {}
+                facet_map[facet] = {'set': source_set, 'source': facet_table}
                 filtering_this_facet = facet_table in filter_clauses and facet in filter_clauses[facet_table]['attr_params']
                 count_jobs[facet] = {}
+                count_clause = None
+                if attr_facet.data_type == Attribute.CONTINUOUS_NUMERIC:
+                    count_clause = _get_bq_range_case_clause(attr_facet, table_info[facet_table]['name'], table_info[facet_table]['alias'], table_info[facet_table]['shared_id_col'])
+                else:
+                    count_clause = "{}.{}, {}.{}".format(table_info[facet_table]['alias'], table_info[facet_table]['shared_id_col'],
+                                          table_info[facet_table]['alias'], facet)
+                group_by_clause = "{}.{}, {}.{}".format(table_info[facet_table]['alias'],
+                                                        table_info[facet_table]['shared_id_col'],
+                                                        table_info[facet_table]['alias'], facet)
                 count_query = query_base.format(
                     facet=facet,
-                    table_clause="`{}` {}".format(image_table, table_info[image_table]['alias']),
-                    count_clause="{}.{}, {}.{}".format(table_info[facet_table]['alias'],table_info[facet_table]['id_col'], table_info[facet_table]['alias'],facet),
+                    table_clause="`{}` {}".format(table_info[image_table]['name'], table_info[image_table]['alias']),
+                    count_clause=count_clause,
+                    group_by_clause=group_by_clause,
                     where_clause="{}".format("WHERE {}".format(" AND ".join(query_filters)) if len(query_filters) else ""),
                     join_clause=""" """.join(joins),
                 )
+                if facet == 'Modality':
+                    print(count_query)
                 # Toggle 'don't filter'
                 if filtering_this_facet:
                     for param in filter_clauses[facet_table]['attr_params'][facet]:
@@ -180,7 +226,6 @@ def get_bq_facet_counts(filters, facets, data_versions):
             num_retries += 1
             still_checking = (num_retries < BQ_ATTEMPT_MAX)
 
-        results = {}
         if not_done:
             logger.error("[ERROR] Timed out while trying to count case/sample totals in BQ")
         else:
@@ -188,29 +233,36 @@ def get_bq_facet_counts(filters, facets, data_versions):
             logger.debug("[BENCHMARKING] Time to finish BQ counts: {}s".format(str(((stop-start)/1000))))
             for facet in count_jobs:
                 bq_results = BigQuerySupport.get_job_results(count_jobs[facet]['job']['jobReference'])
-                if not facet in results:
-                    # If this is a categorical attribute, fetch its list of possible values (so we can know what didn't come
-                    # back in the query)
-                    results[facet] = {
-                        'counts': {},
-                        'total': 0,
-                    }
                 for row in bq_results:
-                    val = row['f'][0]['v']
+                    val = row['f'][0]['v'] if row['f'][0]['v'] is not None else "None"
                     count = row['f'][1]['v']
-                    results[facet]['counts'][val] = int(count)
-                    results[facet]['total'] += int(count)
+                    results['facets'][facet_map[facet]['set']][facet_map[facet]['source']]['facets'][facet][val] = int(count)
+                    if not counted_total:
+                        total += int(count)
+                counted_total = True
+
+        results['facets']['total'] = total
 
     return results
-
-
 
 # Fetch the related metadata from BigQuery
 # filters: dict filter set
 # fields: list of columns to return, string format only
 # data_versions: QuerySet<DataVersion> of the data versions(s) to search
 # returns: { 'results': <BigQuery API v2 result set>, 'schema': <TableSchema Obj> }
-def get_bq_metadata(filters, fields, data_versions, group_by=None, limit=0, offset=0, order_by=None, order_asc=True):
+def get_bq_metadata(filters, fields, data_versions, sources_and_attrs=None, group_by=None, limit=0, offset=0, order_by=None, order_asc=True):
+
+    if not data_versions and not sources_and_attrs:
+        data_versions = DataVersion.objects.filter(active=True)
+
+    if not group_by:
+        group_by = fields
+    else:
+        if type(group_by) is not list:
+            group_by = [group_by]
+        group_by.extend(fields)
+        group_by = set(group_by)
+
     filter_attr_by_bq = {}
     field_attr_by_bq = {}
 
@@ -230,52 +282,33 @@ def get_bq_metadata(filters, fields, data_versions, group_by=None, limit=0, offs
         ON {field_alias}.{field_join_id} = {filter_alias}.{filter_join_id}
     """
 
-    filter_attrs = Attribute.objects.filter(active=True, name__in=list(filters.keys()))
-    # Preserve the order of fields parameter when building field_attrs
-    field_attrs = [Attribute.objects.get(active=True, name=field) for field in fields]
-
-    table_info = {}
-
     image_tables = {}
 
-    for attr in filter_attrs:
-        bqtables = attr.data_sources.all().filter(version__in=data_versions, source_type=DataSource.BIGQUERY).distinct()
-        for bqtable in bqtables:
-            if bqtable.version.data_type == DataVersion.IMAGE_DATA:
-                image_tables[bqtable.name] = bqtable
-            if bqtable.name not in filter_attr_by_bq:
-                filter_attr_by_bq[bqtable.name] = {}
-                table_info[bqtable.name] = {
-                    'id_col': bqtable.shared_id_col
-                }
-                alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
-                table_info[bqtable.name]['alias'] = alias
-                filter_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
-            else:
-                filter_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+    if not sources_and_attrs:
+        filter_attr_by_bq = _build_attr_by_source(list(filters.keys()), data_versions, DataSource.BIGQUERY)
+        field_attr_by_bq = _build_attr_by_source(fields, data_versions, DataSource.BIGQUERY)
+    else:
+        filter_attr_by_bq = sources_and_attrs['filters']
+        field_attr_by_bq = sources_and_attrs['fields']
 
-    for attr in field_attrs:
-        bqtables = attr.data_sources.all().filter(version__active=True, source_type=DataSource.BIGQUERY).distinct()
-        for bqtable in bqtables:
-            if bqtable.version.data_type == DataVersion.IMAGE_DATA:
-                image_tables[bqtable.name] = bqtable
-            if bqtable.name not in field_attr_by_bq:
-                field_attr_by_bq[bqtable.name] = {}
-                field_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
-                table_info[bqtable.name] = {
-                    'id_col': bqtable.shared_id_col
-                }
-                alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
-                table_info[bqtable.name]['alias'] = alias
-            else:
-                field_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+    for attr_set in [filter_attr_by_bq, field_attr_by_bq]:
+        for source in attr_set['sources']:
+            if attr_set['sources'][source]['data_type'] == DataVersion.IMAGE_DATA:
+                image_tables[source] = 1
+
+    table_info = {
+        x: {
+            'name': y['sources'][x]['name'],
+            'alias': y['sources'][x]['name'].split(".")[-1].lower().replace("-", "_"),
+            'shared_id_col': y['sources'][x]['shared_id_col']
+        } for y in [field_attr_by_bq, filter_attr_by_bq] for x in y['sources']
+    }
 
     filter_clauses = {}
     field_clauses = {}
 
-    for bqtable in field_attr_by_bq:
-        alias = table_info[bqtable]['alias']
-        field_clauses[bqtable] = ",".join(["{}.{}".format(alias, x) for x in field_attr_by_bq[bqtable]['attrs']])
+    for bqtable in field_attr_by_bq['sources']:
+        field_clauses[bqtable] = ",".join(["{}.{}".format(table_info[bqtable]['alias'], x) for x in field_attr_by_bq['sources'][bqtable]['list']])
 
     for_union = []
     params = []
@@ -285,15 +318,21 @@ def get_bq_metadata(filters, fields, data_versions, group_by=None, limit=0, offs
         new_order = []
         for order in order_by:
             order_table = Attribute.objects.get(active=True, name=order).data_sources.all().filter(version__in=data_versions, source_type=DataSource.BIGQUERY).distinct().first()
-            new_order.append("{}.{}".format(table_info[order_table.name]['alias'],order))
+            new_order.append("{}.{}".format(table_info[order_table.id]['alias'],order))
         order_by = new_order
 
     if group_by:
         new_groups = []
         for grouping in group_by:
-            group_table = Attribute.objects.get(active=True, name=grouping).data_sources.all().filter(version__in=data_versions,
+            group_table = None
+            if sources_and_attrs:
+                source_set = list(sources_and_attrs['filters']['sources'].keys())
+                source_set.extend(list(sources_and_attrs['fields']['sources'].keys()))
+                group_table = Attribute.objects.get(active=True, name=grouping).data_sources.all().filter(id__in=set(source_set)).distinct().first()
+            else:
+                group_table = Attribute.objects.get(active=True, name=grouping).data_sources.select_related('version').all().filter(version__in=data_versions,
                                                                                                       source_type=DataSource.BIGQUERY).distinct().first()
-            new_groups.append("{}.{}".format(table_info[group_table.name]['alias'], grouping))
+            new_groups.append("{}.{}".format(table_info[group_table.id]['alias'], grouping))
         group_by = new_groups
 
     # We join image tables to corresponding ancillary tables, and union between image tables
@@ -302,52 +341,55 @@ def get_bq_metadata(filters, fields, data_versions, group_by=None, limit=0, offs
         joins = []
         query_filters = []
         fields = [field_clauses[image_table]] if image_table in field_clauses else []
-        if image_table in filter_attr_by_bq:
-            filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[image_table]['attrs']}
-            filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
-                filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
-                case_insens=True
-            )
-            param_sfx += 1
-            query_filters.append(filter_clauses[image_table]['filter_string'])
-            params.append(filter_clauses[image_table]['parameters'])
-        tables_in_query.append(image_table)
-        for filter_bqtable in filter_attr_by_bq:
-            if filter_bqtable != image_table and filter_bqtable not in tables_in_query:
-                filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[filter_bqtable]['attrs']}
-                filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
-                    filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
+        if image_table in filter_attr_by_bq['sources']:
+            filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq['sources'][image_table]['list']}
+            if len(filter_set):
+                filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
+                    filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
                     case_insens=True
                 )
                 param_sfx += 1
+                query_filters.append(filter_clauses[image_table]['filter_string'])
+                params.append(filter_clauses[image_table]['parameters'])
+        tables_in_query.append(image_table)
+        for filter_bqtable in filter_attr_by_bq['sources']:
+            if filter_bqtable not in image_tables and filter_bqtable not in tables_in_query:
+                filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq['sources'][filter_bqtable]['list']}
+                if len(filter_set):
+                    filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
+                        filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
+                        case_insens=True
+                    )
+                    param_sfx += 1
 
-                joins.append(join_clause_base.format(
-                    filter_alias=table_info[filter_bqtable]['alias'],
-                    filter_table=filter_bqtable,
-                    filter_join_id=table_info[filter_bqtable]['id_col'],
-                    field_alias=table_info[image_table]['alias'],
-                    field_join_id=table_info[image_table]['id_col']
-                ))
-                params.append(filter_clauses[filter_bqtable]['parameters'])
-                query_filters.append(filter_clauses[filter_bqtable]['filter_string'])
-                tables_in_query.append(filter_bqtable)
+                    joins.append(join_clause_base.format(
+                        filter_alias=table_info[filter_bqtable]['alias'],
+                        filter_table=table_info[filter_bqtable]['name'],
+                        filter_join_id=table_info[filter_bqtable]['shared_id_col'],
+                        field_alias=table_info[image_table]['alias'],
+                        field_join_id=table_info[image_table]['shared_id_col']
+                    ))
+                    params.append(filter_clauses[filter_bqtable]['parameters'])
+                    query_filters.append(filter_clauses[filter_bqtable]['filter_string'])
+                    tables_in_query.append(filter_bqtable)
 
         # Any remaining field clauses not pulled are for tables not being filtered and which aren't the image table,
         # so we add them last
-        for field_bqtable in field_attr_by_bq:
-            if field_bqtable not in tables_in_query:
-                fields.append(field_clauses[field_bqtable])
+        for field_bqtable in field_attr_by_bq['sources']:
+            if field_bqtable not in image_tables and field_bqtable not in tables_in_query:
+                if len(field_clauses[field_bqtable]):
+                    fields.append(field_clauses[field_bqtable])
                 joins.append(join_clause_base.format(
                     field_alias=table_info[image_table]['alias'],
-                    field_join_id=table_info[image_table]['id_col'],
+                    field_join_id=table_info[image_table]['shared_id_col'],
                     filter_alias=table_info[field_bqtable]['alias'],
-                    filter_table=field_bqtable,
-                    filter_join_id=table_info[field_bqtable]['id_col']
+                    filter_table=table_info[field_bqtable]['name'],
+                    filter_join_id=table_info[field_bqtable]['shared_id_col']
                 ))
 
         for_union.append(query_base.format(
-            field_clause=",".join(fields),
-            table_clause="`{}` {}".format(image_table, table_info[image_table]['alias']),
+            field_clause= ",".join(fields),
+            table_clause="`{}` {}".format(table_info[image_table]['name'], table_info[image_table]['alias']),
             join_clause=""" """.join(joins),
             where_clause="{}".format("WHERE {}".format(" AND ".join(query_filters)) if len(query_filters) else ""),
             order_clause="{}".format("ORDER BY {}".format(", ".join(["{} {}".format(x, "ASC" if order_asc else "DESC") for x in order_by])) if order_by and len(order_by) else ""),
@@ -356,11 +398,66 @@ def get_bq_metadata(filters, fields, data_versions, group_by=None, limit=0, offs
             offset_clause="{}".format("OFFSET {}".format(str(offset)) if offset > 0 else "")
         ))
 
-    full_query_str = """UNION DISTINCT""".join(for_union)
+    full_query_str =  """
+            #standardSQL
+    """ + """UNION DISTINCT""".join(for_union)
 
     results = BigQuerySupport.execute_query_and_fetch_results(full_query_str, params, with_schema=True)
 
     return results
+
+def _get_bq_range_case_clause(attr, table, alias, count_on, include_nulls=True):
+    ranges = Attribute_Ranges.objects.filter(attribute=attr)
+    ranges_case = []
+
+    for attr_range in ranges:
+        if attr_range.gap == "0":
+            # This is a single range, no iteration to be done
+            if attr_range.first == "*":
+                ranges_case.append(
+                    "WHEN {}.{} < {} THEN '{}'".format(alias, attr.name, str(attr_range.last), attr_range.label))
+            elif attr_range.last == "*":
+                ranges_case.append(
+                    "WHEN {}.{} > {} THEN '{}'".format(alias, attr.name, str(attr_range.first), attr_range.label))
+            else:
+                ranges_case.append(
+                    "WHEN {}.{} BETWEEN {} AND {} THEN '{}'".format(alias, attr.name, str(attr_range.first),
+                                                                   str(attr_range.last), attr_range.label))
+        else:
+            # Iterated range
+            cast = int if attr_range.type == Attribute_Ranges.INT else float
+            gap = cast(attr_range.gap)
+            last = cast(attr_range.last)
+            lower = cast(attr_range.first)
+            upper = cast(attr_range.first) + gap
+
+            if attr_range.unbounded:
+                upper = lower
+                lower = "*"
+
+            while lower == "*" or lower < last:
+                if lower == "*":
+                    ranges_case.append(
+                        "WHEN {}.{} < {} THEN {}".format(alias, attr.name, str(upper), "'* TO {}'".format(str(upper))))
+                else:
+                    ranges_case.append(
+                        "WHEN {}.{} BETWEEN {} AND {} THEN {}".format(alias, attr.name, str(lower),
+                                                                       str(lower), "'{} TO {}'".format(str(lower),str(upper))))
+                lower = upper
+                upper = lower + gap
+
+            # If we stopped *at* the end, we need to add one last bucket.
+            if attr_range.unbounded:
+                ranges_case.append(
+                    "WHEN {}.{} > {} THEN {}".format(alias, attr.name, str(attr_range.last), "'{} TO *'".format(str(attr_range.last))))
+
+    if include_nulls:
+        ranges_case.append(
+            "WHEN {}.{} IS NULL THEN 'none'".format(alias, attr.name))
+
+    case_clause = "(CASE {} END) AS {}".format(" ".join(ranges_case), attr.name)
+
+    return case_clause
 
 # Given a set of filters, fields, and data versions, build a full BQ query string
 # NOTE: As written, if a field is found in more than one table in the set of tables, all values from all tables for
@@ -400,9 +497,9 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
                 }
                 alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
                 table_info[bqtable.name]['alias'] = alias
-                filter_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
+                filter_attr_by_bq[bqtable.name]['list'] = [attr.name]
             else:
-                filter_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+                filter_attr_by_bq[bqtable.name]['list'].append(attr.name)
 
     image_tables = {}
 
@@ -413,25 +510,25 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
                 image_tables[bqtable.name] = bqtable
             if bqtable.name not in field_attr_by_bq:
                 field_attr_by_bq[bqtable.name] = {}
-                field_attr_by_bq[bqtable.name]['attrs'] = [attr.name]
+                field_attr_by_bq[bqtable.name]['list'] = [attr.name]
                 table_info[bqtable.name] = {
                     'id_col': bqtable.shared_id_col
                 }
                 alias = bqtable.name.split(".")[-1].lower().replace("-", "_")
                 table_info[bqtable.name]['alias'] = alias
             else:
-                field_attr_by_bq[bqtable.name]['attrs'].append(attr.name)
+                field_attr_by_bq[bqtable.name]['list'].append(attr.name)
 
     filter_clauses = {}
     field_clauses = {}
 
     for bqtable in filter_attr_by_bq:
-        filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[bqtable]['attrs']}
+        filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[bqtable]['list']}
         filter_clauses[bqtable] = BigQuerySupport.build_bq_where_clause(filter_set, field_prefix=table_info[bqtable]['alias'])
 
     for bqtable in field_attr_by_bq:
         alias = table_info[bqtable]['alias']
-        field_clauses[bqtable] = ",".join(["{}.{}".format(alias, x) for x in field_attr_by_bq[bqtable]['attrs']])
+        field_clauses[bqtable] = ",".join(["{}.{}".format(alias, x) for x in field_attr_by_bq[bqtable]['list']])
 
     for_union = []
 
@@ -458,7 +555,7 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
         filter_set = [filter_clauses[image_table]] if image_table in filter_clauses else []
         tables_in_query.append(image_table)
         for filter_bqtable in filter_attr_by_bq:
-            if image_table != filter_bqtable and filter_bqtable not in tables_in_query:
+            if filter_bqtable not in image_tables and filter_bqtable not in tables_in_query:
                 joins.append(join_clause_base.format(
                     field_alias=table_info[image_table]['alias'],
                     field_join_id=table_info[image_table]['id_col'],
@@ -476,7 +573,7 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
         # Any remaining field clauses not pulled are for tables not being filtered and which aren't the image table,
         # so we add them last
         for field_bqtable in field_attr_by_bq:
-            if field_bqtable not in tables_in_query:
+            if field_bqtable not in image_tables and field_bqtable not in tables_in_query:
                 fields.append(field_clauses[field_bqtable])
                 joins.append(join_clause_base.format(
                     field_alias=table_info[image_table]['alias'],
@@ -499,6 +596,8 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
             offset_clause="{}".format("OFFSET {}".format(str(offset)) if offset > 0 else "")
         ))
 
-    full_query_str = """UNION DISTINCT""".join(for_union)
+    full_query_str =  """
+            #standardSQL
+    """ + """UNION DISTINCT""".join(for_union)
 
     return full_query_str

--- a/idc_collections/models.py
+++ b/idc_collections/models.py
@@ -131,12 +131,11 @@ class DataSourceQuerySet(models.QuerySet):
             attrs['sources'] = {}
 
         for ds in self.select_related('version').all():
-            attr_set = ds.attribute_set.filter(default_ui_display=for_ui) if for_ui is not None else ds.attribute_set.all()
+            attr_set = ds.attribute_set.filter(default_ui_display=for_ui, active=True) if for_ui is not None else ds.attribute_set.all()
             attr_set = attr_set.filter(name__in=named_set) if named_set else attr_set
 
             if for_faceting:
-                facet_set = ['BodyPartExamined','Modality','disease_code', 'collection_id', 'vital_status', 'gender', 'race','ethnicity']
-                attr_set = attr_set.filter(data_type=Attribute.CATEGORICAL, active=True, name__in=facet_set) | attr_set.filter(
+                attr_set = attr_set.filter(data_type=Attribute.CATEGORICAL, active=True) | attr_set.filter(
                     id__in=Attribute_Ranges.objects.filter(
                         attribute__in=ds.attribute_set.all().filter(data_type=Attribute.CONTINUOUS_NUMERIC,active=True)
                     ).values_list('attribute__id', flat=True)

--- a/idc_collections/models.py
+++ b/idc_collections/models.py
@@ -115,6 +115,64 @@ class Collection(models.Model):
         )
 
 
+class DataSourceQuerySet(models.QuerySet):
+    def to_dicts(self):
+        return [{
+            "id": ds.id,
+            "name": ds.name,
+            "version": "{}: {}".format(ds.name, ds.version),
+            "type": ds.source_type,
+
+        } for ds in self.select_related('version').all()]
+
+    def get_source_attrs(self, for_ui=None, for_faceting=True, by_source=True, named_set=None):
+        attrs = { 'list': None }
+        if by_source:
+            attrs['sources'] = {}
+
+        for ds in self.select_related('version').all():
+            attr_set = ds.attribute_set.filter(default_ui_display=for_ui) if for_ui is not None else ds.attribute_set.all()
+            attr_set = attr_set.filter(name__in=named_set) if named_set else attr_set
+
+            if for_faceting:
+                facet_set = ['BodyPartExamined','Modality','disease_code', 'collection_id', 'vital_status', 'gender', 'race','ethnicity']
+                attr_set = attr_set.filter(data_type=Attribute.CATEGORICAL, active=True, name__in=facet_set) | attr_set.filter(
+                    id__in=Attribute_Ranges.objects.filter(
+                        attribute__in=ds.attribute_set.all().filter(data_type=Attribute.CONTINUOUS_NUMERIC,active=True)
+                    ).values_list('attribute__id', flat=True)
+                )
+
+            if by_source:
+                attrs['sources'][ds.id] = {
+                    'list': attr_set.values_list('name', flat=True).distinct(),
+                    'attrs': attr_set.distinct(),
+                    'shared_id_col': ds.shared_id_col,
+                    'name': ds.name,
+                    'data_type': ds.version.data_type
+                }
+
+            attrs['list'] = attr_set.values_list('name', flat=True) if not attrs['list'] else (attrs['list'] | attr_set.values_list('name', flat=True))
+
+        attrs['list'] = attrs['list'].distinct()
+
+        return attrs
+
+class DataSourceManager(models.Manager):
+    def get_queryset(self):
+        return DataSourceQuerySet(self.model, using=self._db)
+
+    def search(self, search_terms):
+        terms = [term.strip() for term in search_terms.split()]
+        q_objects = []
+        for term in terms:
+            q_objects.append(Q(name__icontains=term))
+
+        # Start with a bare QuerySet
+        qs = self.get_queryset()
+
+        # Use operator's or_ to string together all of your Q objects.
+        return qs.filter(reduce(operator.and_, [reduce(operator.or_, q_objects), Q(active=True)]))
+
 class DataSource(models.Model):
     QUERY = 'query'
     TERMS = 'terms'
@@ -129,17 +187,18 @@ class DataSource(models.Model):
     version = models.ForeignKey(DataVersion, on_delete=models.CASCADE)
     shared_id_col = models.CharField(max_length=128, null=False, blank=False, default="PatientID")
     source_type = models.CharField(max_length=1, null=False, blank=False, default=SOLR, choices=SOURCE_TYPES)
+    objects = DataSourceManager()
 
     def get_collection_attr(self, for_faceting=True, for_ui=False):
         if for_faceting:
-            ranged_numerics = self.attribute_set.all().filter(
+            ranged_numerics = self.attribute_set.filter(
                 id__in=Attribute_Ranges.objects.filter(
-                    attribute__in=self.attribute_set.all().filter(data_type=Attribute.CONTINUOUS_NUMERIC,active=True)
+                    attribute__in=self.attribute_set.filter(data_type=Attribute.CONTINUOUS_NUMERIC,active=True)
                 ).values_list('attribute__id', flat=True)
             )
-            attr_set = self.attribute_set.all().filter(data_type=Attribute.CATEGORICAL, active=True) | ranged_numerics
+            attr_set = self.attribute_set.filter(data_type=Attribute.CATEGORICAL, active=True) | ranged_numerics
         else:
-            attr_set = self.attribute_set.all()
+            attr_set = self.attribute_set.filter(active=True)
         if for_ui:
             return attr_set.filter(default_ui_display=True)
         return attr_set
@@ -174,7 +233,7 @@ class Attribute(models.Model):
     active = models.BooleanField(default=True)
     is_cross_collex = models.BooleanField(default=False)
     preformatted_values = models.BooleanField(default=False)
-    default_ui_display = models.BooleanField(default=True)
+    default_ui_display = models.BooleanField(default=True, null=False, blank=False)
     data_sources = models.ManyToManyField(DataSource)
 
     def get_display_values(self):

--- a/solr_helpers/__init__.py
+++ b/solr_helpers/__init__.py
@@ -142,10 +142,8 @@ def query_solr(collection=None, fields=None, query_string=None, fqs=None, facets
 
 # Solr facets are the bucket counting; optionally provide a set of filters to *not* be counted for purposes of
 # providing counts on the query filters
-def build_solr_facets(attr_set, filter_tags=None, include_nulls=True, unique=None):
+def build_solr_facets(attrs, filter_tags=None, include_nulls=True, unique=None):
     facets = {}
-
-    attrs = Attribute.objects.filter(name__in=attr_set)
 
     for attr in attrs:
         facet_type = DataSource.get_facet_type(attr)
@@ -158,7 +156,6 @@ def build_solr_facets(attr_set, filter_tags=None, include_nulls=True, unique=Non
                 l_boundary = "[" if attr_range.include_lower else "{"
                 if attr_range.gap == "0":
                     # This is a single range, no iteration to be done
-
                     lower = attr_range.first
                     upper = attr_range.last
                     facet_name = "{}:{}".format(attr.name, attr_range.label) if attr_range.label else "{}:{} to {}".format(attr.name, str(lower), str(upper))


### PR DESCRIPTION
- Support methods for BQ faceted counting via the WebApp
- Adjust BQ metadata and facet counting methods to accept a list of Attribute and Source ORM objects, or, a list of names from which it must determine the sources to use per the provided data versions