### PR TITLE
Sprint 9

### DIFF
--- a/google_helpers/bigquery/bq_support.py
+++ b/google_helpers/bigquery/bq_support.py
@@ -696,8 +696,7 @@ class BigQuerySupport(BigQueryABC):
                             )
                         else:
                             filter_string += "{}{} = @{}".format(
-                                '' if not field_prefix else field_prefix, attr[:attr.rfind('_')],
-                                param_name
+                                '' if not field_prefix else field_prefix, attr, param_name
                             )
                 elif len(values) == 2 and attr.endswith('_btw'):
                     param_name_1 = param_name + '_btw_1'

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -147,7 +147,7 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
             if len(filter_set):
                 filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
                     filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
-                    case_insens=True, with_count_toggle=True
+                    case_insens=True, with_count_toggle=True, type_schema={'sample_type': 'STRING'}
                 )
                 param_sfx += 1
                 query_filters.append(filter_clauses[image_table]['filter_string'])
@@ -159,7 +159,7 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                 if len(filter_set):
                     filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
                         filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
-                        case_insens=True, with_count_toggle=True
+                        case_insens=True, with_count_toggle=True, type_schema={'sample_type': 'STRING'}
                     )
                     param_sfx += 1
 
@@ -173,7 +173,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                     params.append(filter_clauses[filter_bqtable]['parameters'])
                     query_filters.append(filter_clauses[filter_bqtable]['filter_string'])
                     tables_in_query.append(filter_bqtable)
-
         # Submit jobs, toggling the 'don't filter' var for each facet
         for facet_table in facet_attr_by_bq['sources']:
             for attr_facet in facet_attr_by_bq['sources'][facet_table]['attrs']:
@@ -209,7 +208,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                     where_clause="{}".format("WHERE {}".format(" AND ".join(query_filters)) if len(query_filters) else ""),
                     join_clause=""" """.join(facet_joins)
                 )
-                print(count_query)
                 # Toggle 'don't filter'
                 if filtering_this_facet:
                     for param in filter_clauses[facet_table]['attr_params'][facet]:
@@ -220,7 +218,6 @@ def get_bq_facet_counts(filters, facets, data_versions, sources_and_attrs=None):
                 if filtering_this_facet:
                     for param in filter_clauses[facet_table]['attr_params'][facet]:
                         filter_clauses[facet_table]['count_params'][param]['parameterValue']['value'] = 'filtering'
-
         # Poll the jobs until they're done, or we've timed out
         not_done = True
         still_checking = True
@@ -354,7 +351,7 @@ def get_bq_metadata(filters, fields, data_versions, sources_and_attrs=None, grou
             if len(filter_set):
                 filter_clauses[image_table] = BigQuerySupport.build_bq_filter_and_params(
                     filter_set, param_suffix=str(param_sfx), field_prefix=table_info[image_table]['alias'],
-                    case_insens=True
+                    case_insens=True, type_schema={'sample_type': 'STRING'}
                 )
                 param_sfx += 1
                 query_filters.append(filter_clauses[image_table]['filter_string'])
@@ -366,7 +363,7 @@ def get_bq_metadata(filters, fields, data_versions, sources_and_attrs=None, grou
                 if len(filter_set):
                     filter_clauses[filter_bqtable] = BigQuerySupport.build_bq_filter_and_params(
                         filter_set, param_suffix=str(param_sfx), field_prefix=table_info[filter_bqtable]['alias'],
-                        case_insens=True
+                        case_insens=True, type_schema={'sample_type': 'STRING'}
                     )
                     param_sfx += 1
 
@@ -537,7 +534,7 @@ def get_bq_string(filters, fields, data_versions, group_by=None, limit=0, offset
 
     for bqtable in filter_attr_by_bq:
         filter_set = {x: filters[x] for x in filters if x in filter_attr_by_bq[bqtable]['list']}
-        filter_clauses[bqtable] = BigQuerySupport.build_bq_where_clause(filter_set, field_prefix=table_info[bqtable]['alias'])
+        filter_clauses[bqtable] = BigQuerySupport.build_bq_where_clause(filter_set, field_prefix=table_info[bqtable]['alias'], type_schema={'sample_type': 'STRING'})
 
     for bqtable in field_attr_by_bq:
         alias = table_info[bqtable]['alias']


### PR DESCRIPTION
- Fix bug in rare case of single-value integer filter
- Use type_schema for attributes which are corner cases for the type detection
- Reduce unneeded JOINing