### PR TITLE
Sprint 15 

### DIFF
--- a/cohorts/views/views.py
+++ b/cohorts/views/views.py
@@ -855,6 +855,9 @@ def create_manifest_bq_table(request, cohort):
 
     field_list = json.loads(request.GET.get('columns','["PatientID", "collection_id", "StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID", "source_DOI", "crdc_instance_uuid", "gcs_url"]'))
 
+    # We can only ORDER BY columns which we've actually requested
+    order_by = list(set.intersection(set(order_by),set(field_list)))
+
     result = get_bq_metadata(cohort.get_filters_as_dict_simple()[0],field_list,cohort.get_data_versions(active=True),order_by=order_by, output_settings=export_settings)
 
     if result['status'] == 'error':

--- a/cohorts/views/views.py
+++ b/cohorts/views/views.py
@@ -852,11 +852,20 @@ def create_manifest_bq_table(request, cohort):
     }
 
     order_by = ["PatientID", "collection_id", "StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID", "source_DOI", "crdc_instance_uuid", "gcs_url"]
-
     field_list = json.loads(request.GET.get('columns','["PatientID", "collection_id", "StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID", "source_DOI", "crdc_instance_uuid", "gcs_url"]'))
 
     # We can only ORDER BY columns which we've actually requested
     order_by = list(set.intersection(set(order_by),set(field_list)))
+
+    if request.GET.get('header_fields'):
+        selected_header_fields = json.loads(request.GET.get('header_fields'))
+        headers = []
+
+        'cohort_name' in selected_header_fields and headers.append("Manifest for cohort '{}'".format(cohort.name))
+        'user_email' in selected_header_fields and headers.append("User: {}".format(request.user.email))
+        'cohort_filters' in selected_header_fields and headers.append("Filters: {}".format(cohort.get_filter_display_string()))
+
+        export_settings['desc'] = "\n".join(headers)
 
     result = get_bq_metadata(cohort.get_filters_as_dict_simple()[0],field_list,cohort.get_data_versions(active=True),order_by=order_by, output_settings=export_settings)
 

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -1014,18 +1014,18 @@ def get_bq_metadata(filters, fields, data_version, sources_and_attrs=None, group
             #standardSQL
     """ + """UNION DISTINCT""".join(for_union)
 
-    print(full_query_str)
-
     if no_submit:
         results = {"sql_string":full_query_str, "params":params}
     else:
         if output_settings:
             bqs = BigQueryExportFileList(**output_settings['dest'])
-            results = bqs.export_file_list_query_to_bq(full_query_str, params, output_settings['cohort_id'], user_email=output_settings['email'])
+            results = bqs.export_file_list_query_to_bq(
+                full_query_str, params, output_settings['cohort_id'],
+                user_email=output_settings['email'],
+                desc=output_settings.get('desc',None)
+            )
         else:
             results = BigQuerySupport.execute_query_and_fetch_results(full_query_str, params, paginated=paginated)
-
-    print("results in fetch_bq_metadata: {}".format(results))
 
     return results
 


### PR DESCRIPTION
- Fix for #479
- For BQ export, if headers are requested, add them into the table description (except rows and date, which are implicit to the table itself)