### PR TITLE
Series store cart manifest

### DIFF
--- a/cohorts/views/views.py
+++ b/cohorts/views/views.py
@@ -141,7 +141,7 @@ def get_cohort_stats(request, cohort_id, as_json=True):
         'filters_found': True
     }
     try:
-        req = request.GET if request.GET else request.POST
+        req = request.GET if request.method == 'GET' else request.POST
         update = bool(req.get('update', "False").lower() == "true")
         old_cohort = Cohort.objects.get(id=cohort_id, active=True)
         old_cohort.perm = old_cohort.get_perm(request)
@@ -248,7 +248,7 @@ def cohort_detail(request, cohort_id):
     if debug: logger.debug('Called {}'.format(sys._getframe().f_code.co_name))
 
     try:
-        req = request.GET if request.GET else request.POST
+        req = request.GET if request.method == 'GET' else request.POST
         is_dicofdic = (req.get('is_dicofdic', "False").lower() == "true")
         source = req.get('data_source_type', DataSource.SOLR)
         fields = json.loads(req.get('fields', '[]'))
@@ -491,7 +491,7 @@ def cohort_uuids(request, cohort_id=0):
 def create_manifest_bq_table(request, cohorts):
     response = None
     tables = None
-    req = request.GET or request.POST
+    req = request.GET if request.method == 'GET' else request.POST
     try:
         timestamp = datetime.datetime.fromtimestamp(time.time()).strftime('%Y%m%d_%H%M%S')
 
@@ -642,7 +642,7 @@ def create_manifest_bq_table(request, cohorts):
 def download_cohort_manifest(request, cohort_id=0):
     try:
         cohort_ids = []
-        req = request.GET or request.POST
+        req = request.GET if request.method == 'GET' else request.POST
         if cohort_id:
             cohort_ids = [cohort_id]
         else:
@@ -694,7 +694,7 @@ def get_query_str_response(request, cohort_id=0):
     }
     status = 200
 
-    req = request.GET or request.POST
+    req = request.GET if request.method == 'GET' else request.POST
 
     try:
         query = get_query_string(request, cohort_id)
@@ -723,7 +723,7 @@ def get_query_str_response(request, cohort_id=0):
 
 def get_query_string(request, cohort_id=0):
     try:
-        req = request.POST or request.GET
+        req = request.GET if request.method == 'GET' else request.POST
         filters = json.loads(req.get('filters', None) or '{}')
         version = req.get('version', None)
 

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -703,11 +703,11 @@ def submit_manifest_job(
 # Creates a file manifest of the supplied Cohort object or filters and returns a StreamingFileResponse
 def create_file_manifest(request, cohort=None):
     response = None
-    req = request.GET or request.POST
+    req = request.GET if request.method == 'GET' else request.POST
     async_download = bool(req.get('async_download', 'true').lower() == 'true')
     try:
         filters = None
-        req = request.GET or request.POST
+        req = request.GET if request.method == 'GET' else request.POST
         manifest = None
         partitions = None
         filtergrp_list = None
@@ -1900,8 +1900,6 @@ def get_cart_data_studylvl(filtergrp_list, partitions, limit, offset, length, mx
                 limit=int(mxseries), facets=custom_facets, sort=sortStr, counts_only=False, collapse_on=None,
                 uniques=None, with_cursor=None, stats=None, totals=totals, op='AND'
             )
-            print("series result:")
-            print(solr_result_series_lvl)
             if with_records and ('response' in solr_result_series_lvl) and ('docs' in solr_result_series_lvl['response']):
                 serieslvl_found = True
                 for row in solr_result_series_lvl['response']['docs']:
@@ -1927,8 +1925,6 @@ def get_cart_data_studylvl(filtergrp_list, partitions, limit, offset, length, mx
             sort=sortStr, counts_only=False, collapse_on=None, uniques=None, with_cursor=None, stats=None,
             totals=['SeriesInstanceUID'], op='AND', limit=int(limit), offset=int(offset)
         )
-        print("study result:")
-        print(solr_result)
         solr_result['response']['total'] = solr_result['facets']['total_SeriesInstanceUID']
         solr_result['response']['total_instance_size'] = solr_result['facets']['instance_size']
     else:
@@ -2004,7 +2000,7 @@ def get_cart_data_studylvl(filtergrp_list, partitions, limit, offset, length, mx
     if debug:
         solr_result['response']['query_string'] = query_str
         solr_result['response']['query_string_series_lvl'] = query_str_series_lvl
-    print(solr_result['response'])
+
     return solr_result['response']
 
 
@@ -2215,8 +2211,6 @@ def get_cart_manifest(filtergrp_list, partitions, mxstudies, mxseries, field_lis
     manifest ={}
     manifest['docs'] =[]
     solr_result = get_cart_data_studylvl(filtergrp_list, partitions, MAX_FILE_LIST_ENTRIES, 0, mxstudies, MAX_FILE_LIST_ENTRIES, results_lvl = 'SeriesInstanceUID')
-
-    print(solr_result)
 
     if 'total_SeriesInstanceUID' in solr_result:
         manifest['total'] = solr_result['total_SeriesInstanceUID']


### PR DESCRIPTION
Switched to using the series solr store to generate the cart manifest to avoid the issue of having multiple buckets associated with each series whenever a study is split between several buckets. Note that even the series store uses arrays for the bucket data, so we still have to pick the 1st item in the bucket array in generating the manifest.