### PR TITLE
Sprint gw 72

### DIFF
--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -1100,6 +1100,11 @@ def create_query_set(solr_query, sources, source, all_ui_attrs, image_source, Da
                         query_set.append(solr_query['queries'][attr])
                     else:
                         attStr = solr_query['queries'][attr].replace('"', '\\"')
+                        # certain attributes values include quotes, ie Manufacturer = \"GE Healthcare\" which leads to 'subqueries'
+                        # in filter strings with nested quotes, ie,
+                        # _query_:"{!join to=StudyInstanceUID from=StudyInstanceUID}(+Manufacturer:(""GE Healthcare""))"))
+                        # in this case extra backslashes are needed around the inner quotes
+                        attStr = attStr.replace('\\\\"', '\\\\\\"')
                         attStr = '(_query_:"{!join to=' + default_join_field + ' from=' + default_join_field + '}' + attStr + '")'
                         query_set.append(attStr)
                 # If it's in another source for this program, we need to join on that source

--- a/idc_collections/collex_metadata_utils.py
+++ b/idc_collections/collex_metadata_utils.py
@@ -2295,7 +2295,7 @@ def get_cart_data_serieslvl(filtergrp_list, partitions, field_list, limit, offse
             solr_query = build_solr_query(
                 copy.deepcopy(filtergrp),
                 with_tags_for_ex=False,
-                search_child_records_by=None
+                search_child_records_by=None, solr_default_op='AND'
             )
             query_set_for_filt = create_query_set(solr_query, aux_sources, image_source, all_ui_attrs, image_source,
                                                   DataSetType, default_join_field='StudyInstanceUID')

--- a/solr_helpers/__init__.py
+++ b/solr_helpers/__init__.py
@@ -572,6 +572,11 @@ def build_solr_query(filters, comb_with='AND', with_tags_for_ex=False, subq_join
                     "{!join to=%s from=%s}%s" % (search_child_records_by[attr_name], search_child_records_by[attr_name],
                                                  query_str.replace("\"", "\\\"")))
 
+            # certain attributes values include quotes, ie Manufacturer = \"GE Healthcare\" which leads to 'subqueries'
+            # in filter strings with nested quotes, ie,
+            # _query_:"{!join to=StudyInstanceUID from=StudyInstanceUID}(+Manufacturer:(""GE Healthcare""))"))
+            # in this case extra backslashes are needed around the inner quotes
+            query_str = query_str.replace('\\\\"','\\\\\\"')
         full_query_str += query_str
 
         if with_tags_for_ex:


### PR DESCRIPTION
Fixes two bugs:
1. (#1475 in issues) When a manifest includes an attribute in quotes, ie "GE Healthcare", both filter and cart manifest exports were failing on the SOLR query due to the _query_:  subclause. Through trail and error I found the 'correct' number of \ s to use enclosing the quotes. But there may be a better solution.

2.  Cart manifests exports were failing when "None" attributes were included. This is related to the SOLR query using a "AND" as the default operator. A simple change in query syntax fixed the issue